### PR TITLE
changed kubejs-thermal function call to event.custom

### DIFF
--- a/kubejs/server_scripts/mods/ex_nihilo/ex_nihilo.js
+++ b/kubejs/server_scripts/mods/ex_nihilo/ex_nihilo.js
@@ -55,7 +55,13 @@ ServerEvents.recipes(event => {
             input: { ingredient: Ingredient.of(crush).toJson() },
             output: Item.of(result).toJson()
         })
-        event.recipes.thermal.pulverizer(Item.of(result), crush)
+        event.custom({
+            type: 'thermal:pulverizer',
+            ingredient: Ingredient.of(crush).toJson(),
+            result: [
+                Item.of(result).toJson()
+            ]
+        })
         event.recipes.immersiveengineering.crusher(Item.of(result), crush)
         event.custom({
             type: `integrateddynamics:squeezer`,


### PR DESCRIPTION
removed dependency of KubeJS Thermal (https://www.curseforge.com/minecraft/mc-mods/kubejs-thermal) from ex_nihilo.js
to facilitate the removal of the mod(kubejs-thermal), and fix the missing catalyst/fertilizer recipes for Mystical Agriculture seeds in the phytogenic Insolator.
