### PR TITLE
Update ex_nihilo.js

### DIFF
--- a/kubejs/server_scripts/mods/ex_nihilo/ex_nihilo.js
+++ b/kubejs/server_scripts/mods/ex_nihilo/ex_nihilo.js
@@ -106,6 +106,7 @@ ServerEvents.recipes(event => {
     sieve(`flint`, 0.2, '#minecraft:leaves', 'ars_nouveau:purple_archwood_sapling', null)
     sieve(`flint`, 0.2, '#minecraft:leaves', 'ars_nouveau:green_archwood_sapling', null)
     sieve(`flint`, 0.2, '#minecraft:leaves', 'ars_nouveau:red_archwood_sapling', null)
+    sieve(`flint`, 0.2, '#minecraft:leaves', 'ars_nouveau:yellow_archwood_sapling', null)
     
     //Nether sieve
     sieve(`netherite`, 0.3, exRack, `mysticalagriculture:inferium_essence`, null)


### PR DESCRIPTION
Adds Flashing Archwood saplings where the rest of the archwood saplings drop (flint and higher mesh).

Fixes issue #102 