### PR TITLE
Mekanism tier 4 ore buff

### DIFF
--- a/kubejs/server_scripts/mods/mekanism/slurries.js
+++ b/kubejs/server_scripts/mods/mekanism/slurries.js
@@ -1,0 +1,18 @@
+ServerEvents.recipes(event => {
+  event.forEachRecipe(
+    {
+      type: 'mekanism:dissolution',
+    },
+    r => {
+      let multiplier = 2
+      
+      let output = r.json.get("output")
+      let chemicalType = output.get("chemicalType").toString().replace('"', '')
+      let slurry = output.get("slurry")
+      let slurryId = slurry != null ? slurry.toString().replace('"', '') : null
+      if(chemicalType == "slurry" && slurryId && slurryId.contains("dirty")) {
+        output.add("amount", output.get("amount") * multiplier)
+      }
+    }
+  )
+})


### PR DESCRIPTION
Modified Mekanism Tier 4 ore processing because it's useless at the moment compared to Occultism.

Multiplied dirty slurry result by 2 when using Chemical Dissulution Chamber.
It's result in a 6.6x multiplier.

Slightly better than Occultism's 6x but it's not as easy to set it up.